### PR TITLE
Disable TTY

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -236,7 +236,7 @@ func deployment(app *deploymentv1alpha1.Cluster, ca deploymentv1alpha1.ClusterAp
 						},
 						TerminationMessagePath:   "/dev/termination-log",
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-						TTY:                      true,
+						TTY:                      false,
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						SecurityContext: &corev1.SecurityContext{
 							ReadOnlyRootFilesystem: &trueVal,

--- a/controllers/testdata/bot-deployment.yaml
+++ b/controllers/testdata/bot-deployment.yaml
@@ -51,7 +51,6 @@ spec:
             type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
-        tty: true
         volumeMounts:
         - mountPath: /database/
           name: my-test-cluster-gec-bot

--- a/controllers/testdata/processor-deployment.yaml
+++ b/controllers/testdata/processor-deployment.yaml
@@ -51,7 +51,6 @@ spec:
             type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
-        tty: true
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       restartPolicy: Always

--- a/controllers/testdata/slacker-deployment.yaml
+++ b/controllers/testdata/slacker-deployment.yaml
@@ -51,7 +51,6 @@ spec:
             type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
-        tty: true
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       restartPolicy: Always


### PR DESCRIPTION
There's no real reason either way to have a tty or not, but might as well disable it; if one of our python apps decides it needs to start calling sudo or something, then we may as well add another reason for it to fail (there are a few ways it'll fail apart of from this, but one more doesn't hurt).

If this starts to become a hassle then we can revert just as easily